### PR TITLE
Rewrite the plugin to use an instances instead of globals

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,29 +11,19 @@ https://github.com/user-attachments/assets/91f7b555-86d0-4518-9e1d-c3d328c78c68
 
 ```lua
 return {
-  {
-    'sunesimonsen/notes.nvim',
-    dependencies = { 'nvim-telescope/telescope.nvim', },
-    config = function()
-      local notes = require 'notes'
-
-      -- Point this to your notes directory
-      vim.g.notes_dir = '/Users/ssimonsen/Library/CloudStorage/Dropbox/denoted'
-
-      -- Example key-bindings
-
-      -- Fine a note using Telescope
-      vim.keymap.set('n', '<leader>nn', notes.find_note, { desc = 'Find note' })
-      -- Search with live grep across your notes files
-      vim.keymap.set('n', '<leader>ns', notes.search_notes, { desc = 'Search notes' })
-      -- Create a link to another note
-      vim.keymap.set('n', '<leader>nl', notes.link_to_note, { desc = 'Link to note' })
-      -- Toggle a given tag of the note your are editing
-      vim.keymap.set('n', '<leader>nt', notes.toggle_tag, { desc = 'Toggle tag' })
-      -- Retitle the note that you are editing
-      vim.keymap.set('n', '<leader>nr', notes.retitle, { desc = 'Retitle note' })
-    end,
-  }
+  'sunesimonsen/notes.nvim',
+  dependencies = { 'nvim-telescope/telescope.nvim', },
+  opts = {
+    dir = '/Users/ssimonsen/Library/CloudStorage/Dropbox/denoted',
+  },
+  keys = {
+    { '<leader>nn', ':Notes find<CR>', desc = 'Find note', mode = { 'n' } },
+    { '<leader>nl', ':Notes link_to_note<CR>', desc = 'Link to note', mode = { 'n' } },
+    { '<leader>nr', ':Notes retitle<CR>', desc = 'Retitle note', mode = { 'n' } },
+    { '<leader>ns', ':Notes search<CR>', desc = 'Search through notes', mode = { 'n' } },
+    { '<leader>nt', ':Notes toggle_tag<CR>', desc = 'Toggle tag', mode = { 'n' } },
+  },
+  lazy = false,
 }
 
 ```


### PR DESCRIPTION
This rewrite uses an Notes instances and requires setup to be called with the notes dir. It also introduces a Notes command that can be used for bindings.